### PR TITLE
fix filename decryption issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 2. Get token (change with your Google account email used in WhatsApp backup settings)
 
     ```shell
-    wabdd token YOUR_GOOGLE@EMAIL.ADDRESS
-    ```
-
-    ```shell
     wabdd cookie YOUR_GOOGLE@EMAIL.ADRESS -password/-p YOUR_PASSWORD -b BROWSER_NAME(chrome,brave,edge)
+    ```
+    
+    ```shell
+    wabdd token YOUR_GOOGLE@EMAIL.ADDRESS
     ```
 
     - If you need additional information, check [the guide](#getting-the-oauth_token)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 2. Get token (change with your Google account email used in WhatsApp backup settings)
 
     ```shell
-    wabdd cookie YOUR_GOOGLE@EMAIL.ADRESS -password/-p YOUR_PASSWORD -b BROWSER_NAME(chrome,brave,edge)
+    wabdd cookie YOUR_GOOGLE@EMAIL.ADRESS -password/-p YOUR_PASSWORD -output/o OUTPUT_PATH(Default: tokens/oauth_token.txt) -b BROWSER_NAME(chrome,brave,edge)
     ```
     
     ```shell

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
     wabdd token YOUR_GOOGLE@EMAIL.ADDRESS
     ```
 
+    ```shell
+    wabdd cookie YOUR_GOOGLE@EMAIL.ADRESS -password/-p YOUR_PASSWORD -b BROWSER_NAME(chrome,brave,edge)
+    ```
+
     - If you need additional information, check [the guide](#getting-the-oauth_token)
 
 3. Download backup

--- a/wabdd/__main__.py
+++ b/wabdd/__main__.py
@@ -14,7 +14,7 @@
 
 import click
 
-from .commands import decrypt, download, token
+from .commands import decrypt, download, token, cookie
 
 
 @click.group()
@@ -25,6 +25,7 @@ def cli():
 cli.add_command(token.token)
 cli.add_command(download.download)
 cli.add_command(decrypt.decrypt)
+cli.add_command(cookie.cookie)
 
 if __name__ == "__main__":
     cli()

--- a/wabdd/commands/cookie.py
+++ b/wabdd/commands/cookie.py
@@ -1,0 +1,95 @@
+import os
+import click
+import pathlib
+from typing import Optional
+from playwright.sync_api import sync_playwright
+from wabdd.constants import SYSTEM, BROWSER_PATHS, DEFAULT_OUTPUT_PATH
+
+class GoogleAuthClient:
+    def __init__(self, browser_name: str = "chrome"):
+        browser_config = BROWSER_PATHS.get(SYSTEM, {}).get(browser_name.lower())
+        if not browser_config:
+            raise ValueError(f"Unsupported browser: {browser_name} on {SYSTEM}")
+
+        self.user_data_dir = os.path.expandvars(browser_config["user_data"])
+        self.executable_path = os.path.expandvars(browser_config["executable"])
+
+    def get_oauth_token(self, email: str, password: str) -> Optional[str]:
+        with sync_playwright() as playwright:
+            browser_context = playwright.chromium.launch_persistent_context(
+                user_data_dir=self.user_data_dir,
+                executable_path=self.executable_path,
+                headless=False,
+                args=["--disable-blink-features=AutomationControlled"]
+            )
+
+            page = browser_context.new_page()
+            page.goto("https://accounts.google.com/EmbeddedSetup",
+                      wait_until="networkidle",
+                      timeout=60000)
+
+            page.wait_for_load_state("networkidle")
+
+            email_input = page.wait_for_selector("#identifierId")
+            if email_input and email_input.is_enabled():
+                email_input.fill(email)
+
+
+            next_button = page.wait_for_selector("#identifierNext > div > button > div.VfPpkd-RLmnJb")
+            if next_button and next_button.is_enabled():
+                next_button.click()
+
+            page.wait_for_load_state("networkidle")
+
+            password_input = page.wait_for_selector("#password > div.aCsJod.oJeWuf > div > div.Xb9hP > input")
+            if password_input and password_input.is_enabled():
+                password_input.fill(password)
+
+            password_next = page.wait_for_selector("#passwordNext > div > button > div.VfPpkd-RLmnJb")
+            if password_next and password_next.is_enabled():
+                password_next.click()
+
+            page.wait_for_load_state("networkidle")
+
+            consent_next = page.wait_for_selector("#signinconsentNext > div > button > span")
+            if consent_next and consent_next.is_enabled():
+                consent_next.click()
+
+            page.wait_for_timeout(3000)
+
+            cookies = browser_context.cookies()
+            oauth_token = next((c["value"] for c in cookies if c["name"] == "oauth_token"), None)
+
+            browser_context.close()
+            return oauth_token
+
+
+@click.command(name="cookie")
+@click.argument("email")
+@click.option('--password', '-p', help='Google account password', required=True)
+@click.option('--output', '-o', help='Output file path', default=str(DEFAULT_OUTPUT_PATH))
+@click.option('--browser', '-b', help='Browser to use (chrome/brave/edge)', default="chrome")
+def cookie(email: str, password: str, output: str, browser: str):
+    client = GoogleAuthClient(browser)
+
+    try:
+        oauth_token = client.get_oauth_token(email, password)
+
+        if oauth_token:
+            output_path = pathlib.Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if os.path.exists(output_path):
+                os.remove(output_path)
+
+            with open(output_path, 'w') as f:
+                f.write(oauth_token)
+            click.echo(f"Token saved to: {output_path}")
+
+        else:
+            click.echo("Failed to obtain oauth_token", err=True)
+            exit(1)
+
+    except Exception as e:
+        click.echo(f"Error: {str(e)}", err=True)
+        exit(1)

--- a/wabdd/commands/cookie.py
+++ b/wabdd/commands/cookie.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Giacomo Ferretti
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import click
 import pathlib

--- a/wabdd/constants.py
+++ b/wabdd/constants.py
@@ -12,9 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pathlib
+import platform
 from . import __version__
 
 BACKUP_FOLDER = "backups"
 TOKENS_FOLDER = "tokens"
 TOKEN_SUFFIX = "_token.txt"
+
+DEFAULT_OUTPUT_PATH = pathlib.Path(f"{TOKENS_FOLDER}/oauth{TOKEN_SUFFIX}")
+
+SYSTEM = platform.system()
+
+BROWSER_PATHS = {
+    "Windows": {
+        "chrome": {
+            "user_data": "C:\\Users\\%USERNAME%\\AppData\\Local\\Google\\Chrome\\User Data",
+            "executable": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+        },
+        "brave": {
+            "user_data": "C:\\Users\\%USERNAME%\\AppData\\Local\\BraveSoftware\\Brave-Browser\\User Data",
+            "executable": "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe"
+        },
+        "edge": {
+            "user_data": "C:\\Users\\%USERNAME%\\AppData\\Local\\Microsoft\\Edge\\User Data",
+            "executable": "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe"
+        }
+    }
+}
+
 USER_AGENT = f"wagdd/{__version__}"


### PR DESCRIPTION
Problem Description:
When decrypting URL-encoded filenames with Turkish and other languages characters, the function incorrectly transforms the original filename. Example:

Original Filename: Yeni Klasör 2
Decrypted Filename: Yeni+klas%C3%B6r+%282%29

The issue stems from incomplete Unicode character handling during URL decoding, which can:

Corrupt special characters
Misinterpret Turkish character encodings
Potentially break file naming across different systems

And I solved that problems in that pr.

Also you can run the tests;

```python
import re
import pathlib
from urllib.parse import unquote
from typing import Union

def fix_filename(txt: Union[str, pathlib.Path]) -> str:
    if txt is None or txt == '':
        return ''

    decoded = str(txt)
    if '%' in decoded:
        decoded = decoded.replace('%2B', '§PLUS§')
        decoded = unquote(decoded)
        decoded = decoded.replace('+', ' ')
        decoded = decoded.replace('§PLUS§', '+')

    if not decoded or set(decoded) <= {' ', '+'}:
        if all(c == '+' for c in decoded):
            return decoded.replace('+', '')
        return ''

    FILLER = '-'
    EXCLUDED_CHRS = set(r'<>:"/\|?*\0')
    DEVICE_NAMES = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4',
                    'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2',
                    'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
                    'CONIN$', 'CONOUT$', '..', '.'}

    result = ''.join(x if x not in EXCLUDED_CHRS and (ord(x) >= 32 or ord(x) > 127) else FILLER for x in decoded)

    if result.upper() in DEVICE_NAMES:
        result = f'-{result}-'

    result = result[:255]
    result = re.sub(r'^[. ]', FILLER, result)
    result = re.sub(r'[. ]$', FILLER, result)

    return result if result else ''

def test_filename_fixes():
    test_cases = [
        ("Yeni+klas%C3%B6r+%282%29", "Yeni klasör (2)"),
        ("Dosya%20adı.txt", "Dosya adı.txt"),
        ("Yeni klasör (2)+", "Yeni klasör (2)+"),
        ("Document+.txt", "Document+.txt"),
        ("Hello+World%2B", "Hello World+"),
        ("Test%2B+File", "Test+ File"),
        ("%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%2B", "Пример+"),
        ("%E4%BD%A0%E5%A5%BD+%2B+File.txt", "你好 + File.txt"),
        ("%F0%9F%98%80+Smile%2B", "😀 Smile+"),
        ("plain_filename.txt", "plain_filename.txt"),
        ("Hello World+.txt", "Hello World+.txt"),
        ("%2BFile%2B", "+File+"),
        ("No+encoding%21", "No encoding!"),
        ("File%20Name%21%40%23%24.txt", "File Name!@#$.txt"),
        ("%C3%87%C4%B1lg%C4%B1n+Dosya.txt", "Çılgın Dosya.txt"),
    ]

    failed_cases = []
    for encoded, expected in test_cases:
        result = fix_filename(pathlib.Path(encoded))
        if str(result) != expected:
            failed_cases.append({
                'input': encoded,
                'expected': expected,
                'got': result
            })
            print(f"\nTest case:")
            print(f"Input:    {encoded}")
            print(f"Expected: {expected}")
            print(f"Got:      {result}")
            print(f"Pass:     False")

    if failed_cases:
        print("\nFailed Test Cases:")
        for case in failed_cases:
            print(f"Input: {case['input']}")
            print(f"Expected: {case['expected']}")
            print(f"Got: {case['got']}\n")
    else:
        print("All test cases passed successfully!")

test_filename_fixes()
```