### PR TITLE
fix: correctly skip excluded files

### DIFF
--- a/wabdd/commands/download.py
+++ b/wabdd/commands/download.py
@@ -146,12 +146,11 @@ class DownloaderWorker(Thread):
 
                 # Check if file should be excluded
                 if self.exclude_pattern:
-                    for pattern in self.exclude_pattern:
-                        if fnmatch.fnmatch(real_path, pattern):
-                            self.progress.console.print(
-                                f"Skipping {real_path} (excluded)"
-                            )
-                            continue
+                    if any(fnmatch.fnmatch(real_path, pattern) for pattern in self.exclude_pattern):
+                        self.progress.console.print(
+                            f"Skipping {real_path} (excluded)"
+                        )
+                        continue
 
                 # Check if file is already downloaded
                 local_file = self.output / stripped_filepath


### PR DESCRIPTION
I noticed downloading a backup was taking some time, despite me excluding all media. Turns out, there was a little issue in the exclusion logic where it wouldn't actually skip downloading excluded files. This should fix that.